### PR TITLE
fix: 修复 RawRequest/RawResponse nil 导致的 panic

### DIFF
--- a/resty.go
+++ b/resty.go
@@ -62,7 +62,9 @@ func onBeforeRequest(tracer oteltrace.Tracer, cfg *config) resty.RequestMiddlewa
 func onAfterResponse(cfg *config) resty.ResponseMiddleware {
 	return func(c *resty.Client, res *resty.Response) error {
 		span := trace.SpanFromContext(res.Request.Context())
-		span.SetAttributes(httpconv.ClientResponse(res.RawResponse)...)
+		if res.RawResponse != nil {
+			span.SetAttributes(httpconv.ClientResponse(res.RawResponse)...)
+		}
 
 		// Setting request attributes here since res.Request.RawRequest is nil
 		// in onBeforeRequest.
@@ -88,8 +90,14 @@ func onError(cfg *config) resty.ErrorHook {
 }
 
 func setRequestAttributes(span oteltrace.Span, cfg *config, req *resty.Request) oteltrace.Span {
+	if req.RawRequest == nil {
+		return span
+	}
+
 	span.SetAttributes(httpconv.ClientRequest(req.RawRequest)...)
-	span.SetAttributes(attribute.String("http.path", req.RawRequest.URL.Path))
+	if req.RawRequest.URL != nil {
+		span.SetAttributes(attribute.String("http.path", req.RawRequest.URL.Path))
+	}
 
 	if cfg.HideURL {
 		span.SetAttributes(semconv.HTTPURLKey.String("<redacted>"))


### PR DESCRIPTION
URL 解析失败时 req.RawRequest 为 nil，setRequestAttributes 直接访问 req.RawRequest 和 req.RawRequest.URL.Path 触发 nil pointer dereference。

- setRequestAttributes: req.RawRequest == nil 时提前返回
- setRequestAttributes: 访问 URL.Path 前检查 URL != nil
- onAfterResponse: res.RawResponse == nil 时跳过 ClientResponse 属性设置